### PR TITLE
Support PostgreSQL 15

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild.plugin", name: "database", version: "2.0.0-RC.4", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "database", version: "2.0.0-RC.5", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/groovy/org/savantbuild/plugin/database/DatabasePlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/database/DatabasePlugin.groovy
@@ -163,7 +163,7 @@ class DatabasePlugin extends BaseGroovyPlugin {
       if (settings.grantUsername) {
         output.infoln("Granting privileges to [${settings.grantUsername}]")
         execAndWait(["psql", "-U", createUsername, settings.createArguments, "-c", "GRANT ALL PRIVILEGES ON DATABASE ${settings.name} TO ${settings.grantUsername}"])
-        execAndWait(["psql", "-U", createUsername, settings.createArguments, "-c", "GRANT ALL PRIVILEGES ON DATABASE ${settings.name} TO ${settings.grantUsername}"])
+        execAndWait(["psql", "-U", createUsername, settings.createArguments, "-c", "ALTER DATABASE ${settings.name} OWNER TO ${settings.grantUsername}"])
       }
     } else {
       fail("Unsupported database type [${settings.type}]")


### PR DESCRIPTION
**Issue**: 
- https://github.com/FusionAuth/fusionauth-issues/issues/2015

Breaking changes in PostgreSQL 15 requires explicit permissions to create objects in `public` schema. This change sets the database owner to the `settings.grantUsername` user, which effectively grants the permission.

**Related PR**:
- https://github.com/inversoft/inversoft-maintenance-mode/pull/2
